### PR TITLE
fix: Qt5::Widgets is invalid for pkgconfig

### DIFF
--- a/cmake/qt.cmake
+++ b/cmake/qt.cmake
@@ -3,4 +3,4 @@ find_package(Qt5Widgets REQUIRED)
 include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 target_link_libraries(${bin} Qt5::Widgets)
 
-set(${bin}_pkg_config_requires ${${bin}_pkg_config_requires} Qt5::Widgets)
+set(${bin}_pkg_config_requires ${${bin}_pkg_config_requires} Qt5Widgets)


### PR DESCRIPTION
> -- Checking for module 'fakevim'
--   Package 'Qt5::Widgets', required by 'fakevim', not found
CMake Error at /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:603 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:825 (_pkg_check_modules_internal)
  dmarked/CMakeLists.txt:36 (pkg_check_modules)

here should be Qt5Widgets